### PR TITLE
Add IR builder, SSA generator, and formatters

### DIFF
--- a/hulk-compiler/src/ir/block.rs
+++ b/hulk-compiler/src/ir/block.rs
@@ -48,4 +48,28 @@ impl BasicBlock {
             self.successors.push(successor);
         }
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.instructions.is_empty()
+    }
+
+    pub fn instruction_count(&self) -> usize {
+        self.instructions.len()
+    }
+
+    pub fn fmt_display(&self, indent: usize) -> String {
+        let indent_str = " ".repeat(indent);
+        let next_indent_str = " ".repeat(indent + 2);
+        let mut result = format!("{}Block {}:\n", indent_str, self.id.0);
+
+        for instr in &self.instructions {
+            result.push_str(&format!(
+                "{}{}\n",
+                next_indent_str,
+                instr.fmt_display()
+            ));
+        }
+
+        result
+    }
 }

--- a/hulk-compiler/src/ir/instruction.rs
+++ b/hulk-compiler/src/ir/instruction.rs
@@ -5,6 +5,7 @@
 
 use super::block::BasicBlockId;
 use super::value::IRValueId;
+use std::fmt;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IRBinaryOp {
@@ -35,6 +36,18 @@ pub enum IROperand {
     Float(f64),
     Boolean(bool),
     Text(String),
+}
+
+impl IROperand {
+    pub fn fmt_display(&self) -> String {
+        match self {
+            IROperand::Value(id) => id.0.clone(),
+            IROperand::Integer(i) => i.to_string(),
+            IROperand::Float(f) => f.to_string(),
+            IROperand::Boolean(b) => b.to_string(),
+            IROperand::Text(s) => format!("\"{}\"", s),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -97,5 +110,251 @@ impl IRInstruction {
             } => Some(target),
             _ => None,
         }
+    }
+
+    pub fn uses_value(&self, value_id: &IRValueId) -> bool {
+        match &self.kind {
+            IRInstructionKind::Assign { value, .. } => operand_uses_value(value, value_id),
+            IRInstructionKind::Binary { left, right, .. } => {
+                operand_uses_value(left, value_id) || operand_uses_value(right, value_id)
+            }
+            IRInstructionKind::Unary { operand, .. } => operand_uses_value(operand, value_id),
+            IRInstructionKind::Phi { incoming, .. } => {
+                incoming.iter().any(|(vid, _)| vid == value_id)
+            }
+            IRInstructionKind::Branch { condition, .. } => operand_uses_value(condition, value_id),
+            IRInstructionKind::Return(Some(operand)) => operand_uses_value(operand, value_id),
+            IRInstructionKind::Call { arguments, .. } => {
+                arguments.iter().any(|arg| operand_uses_value(arg, value_id))
+            }
+            _ => false,
+        }
+    }
+
+    pub fn is_terminator(&self) -> bool {
+        matches!(
+            &self.kind,
+            IRInstructionKind::Jump { .. }
+                | IRInstructionKind::Branch { .. }
+                | IRInstructionKind::Return(_)
+        )
+    }
+
+    pub fn is_arithmetic(&self) -> bool {
+        matches!(
+            &self.kind,
+            IRInstructionKind::Binary { .. }
+                | IRInstructionKind::Unary { .. }
+                | IRInstructionKind::Assign { .. }
+        )
+    }
+
+    pub fn is_control_flow(&self) -> bool {
+        matches!(
+            &self.kind,
+            IRInstructionKind::Jump { .. }
+                | IRInstructionKind::Branch { .. }
+                | IRInstructionKind::Return(_)
+        )
+    }
+
+    pub fn is_phi(&self) -> bool {
+        matches!(&self.kind, IRInstructionKind::Phi { .. })
+    }
+
+    pub fn is_call(&self) -> bool {
+        matches!(&self.kind, IRInstructionKind::Call { .. })
+    }
+
+    pub fn is_nop(&self) -> bool {
+        matches!(&self.kind, IRInstructionKind::Nop)
+    }
+
+    pub fn target_block(&self) -> Option<&BasicBlockId> {
+        match &self.kind {
+            IRInstructionKind::Jump { target } => Some(target),
+            IRInstructionKind::Branch {
+                then_block,
+                ..
+            } => Some(then_block),
+            _ => None,
+        }
+    }
+
+    pub fn successor_blocks(&self) -> Vec<&BasicBlockId> {
+        match &self.kind {
+            IRInstructionKind::Jump { target } => vec![target],
+            IRInstructionKind::Branch {
+                then_block,
+                else_block,
+                ..
+            } => vec![then_block, else_block],
+            _ => vec![],
+        }
+    }
+
+    pub fn phi_incoming(&self) -> Option<&Vec<(IRValueId, BasicBlockId)>> {
+        match &self.kind {
+            IRInstructionKind::Phi { incoming, .. } => Some(incoming),
+            _ => None,
+        }
+    }
+
+    pub fn phi_from_block(
+        &self,
+        block_id: &BasicBlockId,
+    ) -> Option<&IRValueId> {
+        match &self.kind {
+            IRInstructionKind::Phi { incoming, .. } => {
+                incoming
+                    .iter()
+                    .find(|(_, bid)| bid == block_id)
+                    .map(|(vid, _)| vid)
+            }
+            _ => None,
+        }
+    }
+
+    pub fn phi_incoming_count(&self) -> Option<usize> {
+        match &self.kind {
+            IRInstructionKind::Phi { incoming, .. } => Some(incoming.len()),
+            _ => None,
+        }
+    }
+
+    pub fn phi_blocks(&self) -> Option<Vec<&BasicBlockId>> {
+        match &self.kind {
+            IRInstructionKind::Phi { incoming, .. } => {
+                Some(incoming.iter().map(|(_, bid)| bid).collect())
+            }
+            _ => None,
+        }
+    }
+
+    pub fn validate_phi(&self) -> Result<(), String> {
+        match &self.kind {
+            IRInstructionKind::Phi { incoming, target } => {
+                if incoming.len() < 2 {
+                    return Err(format!(
+                        "Phi node {:?} must have at least 2 incoming values, has {}",
+                        target,
+                        incoming.len()
+                    ));
+                }
+
+                for i in 0..incoming.len() {
+                    for j in (i + 1)..incoming.len() {
+                        if incoming[i].1 == incoming[j].1 {
+                            return Err(format!(
+                                "Phi node {:?} has duplicate incoming block: {:?}",
+                                target, incoming[i].1
+                            ));
+                        }
+                    }
+                }
+
+                Ok(())
+            }
+            _ => Err("Not a phi instruction".to_string()),
+        }
+    }
+
+    pub fn fmt_display(&self) -> String {
+        match &self.kind {
+            IRInstructionKind::Assign { target, value } => {
+                format!("{} = {}", target.0, value.fmt_display())
+            }
+            IRInstructionKind::Binary {
+                target,
+                op,
+                left,
+                right,
+            } => {
+                let op_str = match op {
+                    IRBinaryOp::Add => "+",
+                    IRBinaryOp::Sub => "-",
+                    IRBinaryOp::Mul => "*",
+                    IRBinaryOp::Div => "/",
+                    IRBinaryOp::And => "&&",
+                    IRBinaryOp::Or => "||",
+                    IRBinaryOp::Eq => "==",
+                    IRBinaryOp::Ne => "!=",
+                    IRBinaryOp::Lt => "<",
+                    IRBinaryOp::Le => "<=",
+                    IRBinaryOp::Gt => ">",
+                    IRBinaryOp::Ge => ">=",
+                };
+                format!(
+                    "{} = {} {} {}",
+                    target.0,
+                    left.fmt_display(),
+                    op_str,
+                    right.fmt_display()
+                )
+            }
+            IRInstructionKind::Unary {
+                target,
+                op,
+                operand,
+            } => {
+                let op_str = match op {
+                    IRUnaryOp::Neg => "-",
+                    IRUnaryOp::Not => "!",
+                };
+                format!("{} = {}{}", target.0, op_str, operand.fmt_display())
+            }
+            IRInstructionKind::Phi { target, incoming } => {
+                let values = incoming
+                    .iter()
+                    .map(|(v, b)| format!("{}:{}", v.0, b.0))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("{} = phi({})", target.0, values)
+            }
+            IRInstructionKind::Jump { target } => {
+                format!("jump {}", target.0)
+            }
+            IRInstructionKind::Branch {
+                condition,
+                then_block,
+                else_block,
+            } => {
+                format!(
+                    "br {} {} {}",
+                    condition.fmt_display(),
+                    then_block.0,
+                    else_block.0
+                )
+            }
+            IRInstructionKind::Return(operand) => {
+                match operand {
+                    Some(op) => format!("return {}", op.fmt_display()),
+                    None => "return".to_string(),
+                }
+            }
+            IRInstructionKind::Call {
+                target,
+                callee,
+                arguments,
+            } => {
+                let args = arguments
+                    .iter()
+                    .map(|arg| arg.fmt_display())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                match target {
+                    Some(t) => format!("{} = call {}({})", t.0, callee, args),
+                    None => format!("call {}({})", callee, args),
+                }
+            }
+            IRInstructionKind::Nop => "nop".to_string(),
+        }
+    }
+}
+
+fn operand_uses_value(operand: &IROperand, value_id: &IRValueId) -> bool {
+    match operand {
+        IROperand::Value(vid) => vid == value_id,
+        _ => false,
     }
 }

--- a/hulk-compiler/src/ir/lowering.rs
+++ b/hulk-compiler/src/ir/lowering.rs
@@ -6,7 +6,10 @@
 
 use crate::parser::ast::Program;
 
-use super::module::IRModule;
+use super::block::BasicBlock;
+use super::instruction::IRInstruction;
+use super::module::{IRFunction, IRModule};
+use super::value::IRValue;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IRLoweringError {
@@ -62,5 +65,127 @@ impl IRLoweringResult {
     pub fn with_warning(mut self, warning: impl Into<String>) -> Self {
         self.warnings.push(warning.into());
         self
+    }
+}
+
+#[derive(Debug)]
+pub struct IRBuilder {
+    module: IRModule,
+    current_function: Option<String>,
+}
+
+impl IRBuilder {
+    pub fn new(module_name: impl Into<String>) -> Self {
+        Self {
+            module: IRModule::new(module_name),
+            current_function: None,
+        }
+    }
+
+    pub fn create_function(
+        &mut self,
+        name: impl Into<String>,
+        parameters: Vec<IRValue>,
+        return_type: Option<String>,
+    ) -> Result<(), IRLoweringError> {
+        let name_str = name.into();
+
+        if self.module.function(&name_str).is_some() {
+            return Err(IRLoweringError::new(format!(
+                "Function '{}' already exists",
+                name_str
+            )));
+        }
+
+        let mut func = IRFunction::new(name_str.clone());
+        func.parameters = parameters;
+        func.return_type = return_type;
+
+        self.module.add_function(func);
+        self.current_function = Some(name_str);
+        Ok(())
+    }
+
+    pub fn create_block_in_function(
+        &mut self,
+        function_name: impl AsRef<str>,
+        block_name: impl Into<String>,
+    ) -> Result<(), IRLoweringError> {
+        let func_name = function_name.as_ref();
+        let block_name_str = block_name.into();
+
+        let func = self
+            .module
+            .function_mut(func_name)
+            .ok_or_else(|| IRLoweringError::new(format!("Function '{}' not found", func_name)))?;
+
+        if func.block(&super::block::BasicBlockId::new(&block_name_str)).is_some() {
+            return Err(IRLoweringError::new(format!(
+                "Block '{}' already exists in function '{}'",
+                block_name_str, func_name
+            )));
+        }
+
+        let block = BasicBlock::new(block_name_str);
+        func.add_block(block);
+        Ok(())
+    }
+
+    pub fn add_instruction_to_block(
+        &mut self,
+        function_name: impl AsRef<str>,
+        block_name: impl AsRef<str>,
+        instruction: IRInstruction,
+    ) -> Result<(), IRLoweringError> {
+        let func_name = function_name.as_ref();
+        let block_name_str = block_name.as_ref();
+
+        let func = self
+            .module
+            .function_mut(func_name)
+            .ok_or_else(|| IRLoweringError::new(format!("Function '{}' not found", func_name)))?;
+
+        let block_id = super::block::BasicBlockId::new(block_name_str);
+        let block = func.block_mut(&block_id).ok_or_else(|| {
+            IRLoweringError::new(format!(
+                "Block '{}' not found in function '{}'",
+                block_name_str, func_name
+            ))
+        })?;
+
+        block.push_instruction(instruction);
+        Ok(())
+    }
+
+    pub fn set_current_function(&mut self, name: impl Into<String>) {
+        self.current_function = Some(name.into());
+    }
+
+    pub fn current_function(&self) -> Option<&str> {
+        self.current_function.as_deref()
+    }
+
+    pub fn function_exists(&self, name: &str) -> bool {
+        self.module.function(name).is_some()
+    }
+
+    pub fn block_exists(&self, function_name: &str, block_name: &str) -> bool {
+        if let Some(func) = self.module.function(function_name) {
+            func.block(&super::block::BasicBlockId::new(block_name)).is_some()
+        } else {
+            false
+        }
+    }
+
+    pub fn function_count(&self) -> usize {
+        self.module.function_count()
+    }
+
+    pub fn build(self) -> IRModule {
+        self.module
+    }
+
+    pub fn fmt_display(&self) -> String {
+        self.module.fmt_display()
     }
 }

--- a/hulk-compiler/src/ir/mod.rs
+++ b/hulk-compiler/src/ir/mod.rs
@@ -26,10 +26,10 @@ pub use block::{BasicBlock, BasicBlockId};
 #[allow(unused_imports)]
 pub use instruction::{IRBinaryOp, IRInstruction, IRInstructionKind, IROperand, IRUnaryOp};
 #[allow(unused_imports)]
-pub use lowering::{IRLoweringContext, IRLoweringError, IRLoweringResult};
+pub use lowering::{IRBuilder, IRLoweringContext, IRLoweringError, IRLoweringResult};
 #[allow(unused_imports)]
 pub use module::{IRFunction, IRModule};
 #[allow(unused_imports)]
-pub use naming::IRNaming;
+pub use naming::{IRNaming, SSAValueGenerator};
 #[allow(unused_imports)]
 pub use value::{IRValue, IRValueId, IRValueKind};

--- a/hulk-compiler/src/ir/module.rs
+++ b/hulk-compiler/src/ir/module.rs
@@ -40,6 +40,38 @@ impl IRFunction {
     pub fn block_mut(&mut self, id: &BasicBlockId) -> Option<&mut BasicBlock> {
         self.blocks.iter_mut().find(|block| &block.id == id)
     }
+
+    pub fn block_count(&self) -> usize {
+        self.blocks.len()
+    }
+
+    pub fn fmt_display(&self, indent: usize) -> String {
+        let indent_str = " ".repeat(indent);
+        let next_indent_str = " ".repeat(indent + 2);
+
+        let params = self
+            .parameters
+            .iter()
+            .map(|p| {
+                let ty = p.ty.as_deref().unwrap_or("?");
+                format!("{}: {}", p.id.0, ty)
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let return_type = self.return_type.as_deref().unwrap_or("?");
+
+        let mut result = format!(
+            "{}Function: {}({}) -> {}\n",
+            indent_str, self.name, params, return_type
+        );
+
+        for block in &self.blocks {
+            result.push_str(&block.fmt_display(indent + 2));
+        }
+
+        result
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -66,5 +98,17 @@ impl IRModule {
 
     pub fn function_mut(&mut self, name: &str) -> Option<&mut IRFunction> {
         self.functions.iter_mut().find(|function| function.name == name)
+    }
+
+    pub fn function_count(&self) -> usize {
+        self.functions.len()
+    }
+
+    pub fn fmt_display(&self) -> String {
+        let mut result = format!("Module: {}\n", self.name);
+        for function in &self.functions {
+            result.push_str(&function.fmt_display(2));
+        }
+        result
     }
 }

--- a/hulk-compiler/src/ir/naming.rs
+++ b/hulk-compiler/src/ir/naming.rs
@@ -30,3 +30,40 @@ impl IRNaming {
         format!("%p{}", index)
     }
 }
+
+#[derive(Debug, Clone)]
+pub struct SSAValueGenerator {
+    counter: usize,
+}
+
+impl SSAValueGenerator {
+    pub fn new() -> Self {
+        Self { counter: 0 }
+    }
+
+    pub fn next_value(&mut self) -> String {
+        let name = IRNaming::temporary_name(self.counter);
+        self.counter += 1;
+        name
+    }
+
+    pub fn next_parameter(&mut self) -> String {
+        let name = IRNaming::parameter_name(self.counter);
+        self.counter += 1;
+        name
+    }
+
+    pub fn reset(&mut self) {
+        self.counter = 0;
+    }
+
+    pub fn current_count(&self) -> usize {
+        self.counter
+    }
+}
+
+impl Default for SSAValueGenerator {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/hulk-compiler/src/ir/value.rs
+++ b/hulk-compiler/src/ir/value.rs
@@ -29,6 +29,7 @@ pub struct IRValue {
     pub kind: IRValueKind,
     pub ty: Option<String>,
     pub span: Option<Span>,
+    pub dependencies: Vec<IRValueId>,
 }
 
 impl IRValue {
@@ -38,6 +39,7 @@ impl IRValue {
             kind,
             ty: None,
             span: None,
+            dependencies: Vec::new(),
         }
     }
 
@@ -49,5 +51,73 @@ impl IRValue {
     pub fn with_span(mut self, span: Span) -> Self {
         self.span = Some(span);
         self
+    }
+
+    pub fn is_parameter(&self) -> bool {
+        matches!(self.kind, IRValueKind::Parameter)
+    }
+
+    pub fn is_temporary(&self) -> bool {
+        matches!(self.kind, IRValueKind::Temporary)
+    }
+
+    pub fn is_constant(&self) -> bool {
+        matches!(self.kind, IRValueKind::Constant)
+    }
+
+    pub fn is_phi(&self) -> bool {
+        matches!(self.kind, IRValueKind::Phi)
+    }
+
+    pub fn with_dependencies(mut self, deps: Vec<IRValueId>) -> Self {
+        self.dependencies = deps;
+        self
+    }
+
+    pub fn add_dependency(&mut self, dep: IRValueId) {
+        if !self.dependencies.contains(&dep) {
+            self.dependencies.push(dep);
+        }
+    }
+
+    pub fn get_dependencies(&self) -> &[IRValueId] {
+        &self.dependencies
+    }
+
+    pub fn depends_on(&self, value_id: &IRValueId) -> bool {
+        self.dependencies.contains(value_id)
+    }
+
+    pub fn has_dependencies(&self) -> bool {
+        !self.dependencies.is_empty()
+    }
+
+    pub fn dependency_count(&self) -> usize {
+        self.dependencies.len()
+    }
+
+    pub fn fmt_display(&self) -> String {
+        let kind_str = match self.kind {
+            IRValueKind::Temporary => "temp",
+            IRValueKind::Parameter => "param",
+            IRValueKind::Constant => "const",
+            IRValueKind::Phi => "phi",
+            IRValueKind::Named => "named",
+        };
+
+        let type_str = self.ty.as_deref().unwrap_or("?");
+        let dep_str = if self.dependencies.is_empty() {
+            String::new()
+        } else {
+            let deps = self
+                .dependencies
+                .iter()
+                .map(|d| d.0.clone())
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!(" [deps: {}]", deps)
+        };
+
+        format!("{}: {} ({}){}", self.id.0, kind_str, type_str, dep_str)
     }
 }


### PR DESCRIPTION
Introduce IRBuilder for constructing modules/functions/blocks and adding instructions, plus helper queries (function_exists, block_exists, counts, build). Add SSAValueGenerator for producing SSA names. Extend IR types with many utility and formatting methods: BasicBlock (is_empty, instruction_count, fmt_display), IRInstruction and IROperand (fmt_display, operand checks, uses_value, terminator/arithmetic/control-flow/phi/call/nop predicates, phi helpers and validation, successor/target accessors), IRFunction/IRModule fmt_display and count helpers, and IRValue dependency tracking and inspectors (dependencies field, add/get/has/depends_on, fmt_display). Export new types from mod.rs. These changes improve IR construction, inspection, validation and textual debugging output.